### PR TITLE
Refactor/fix configs and add forwarder for read commands

### DIFF
--- a/src/solarflow-status.py
+++ b/src/solarflow-status.py
@@ -164,6 +164,11 @@ def on_local_message(client, userdata, msg):
             log.info("Online mode: forwarding limit command to Zendure Cloud")
             set_zendure_limit(payload)
 
+    if "properties/read" in msg.topic:
+        if not offline_mode:
+            log.info("Online mode: forwarding read command to Zendure Cloud")
+            zendure_update(payload)
+
     if "batteries" in msg.topic:
         sn = msg.topic.split('/')[-2]
         if property not in  ["socLevel", "power","maxTemp"]:
@@ -277,6 +282,7 @@ def local_subscribe(client: mqtt_client):
     report_topic = f'/{device_details["productKey"]}/+/properties/report'
     log_topic = f'/{device_details["productKey"]}/+/log'
     iot_topic = f'iot/{device_details["productKey"]}/+/properties/write'
+    iot_topic_r = f'iot/{device_details["productKey"]}/+/properties/read'
     client.subscribe("solarflow-hub/telemetry/#")
     client.subscribe("solarflow-hub/control/#")
     client.subscribe("solarflow-hub/+/telemetry/#")
@@ -291,6 +297,7 @@ def local_subscribe(client: mqtt_client):
     client.subscribe(report_topic)
     client.subscribe(log_topic)
     client.subscribe(iot_topic)
+    client.subscribe(iot_topic_r)
     client.on_message = on_local_message
 
 def get_auth() -> ZenAuth:

--- a/src/solarflow-status.py
+++ b/src/solarflow-status.py
@@ -319,13 +319,9 @@ def zendure_mqtt_background_task():
 
     zendure_subscribe(client,auth)
     client.loop_start()
-    # request a time sync
-    payload = {
-        "messageId":"123",
-        "deviceId": auth.deviceKey,
-        "timestamp": int(time.time())
-    }
-    client.publish(f'/{auth.productKey}/{auth.deviceKey}/time-sync',json.dumps(payload))
+
+    # Request update of all topics
+    zendure_update()
 
 def local_mqtt_background_task():
     client = None
@@ -369,6 +365,11 @@ def set_zendure_limit(payload):
     global zendure_client
     zendure_client.publish(f'iot/{device_details["productKey"]}/{device_details["deviceKey"]}/properties/write', payload)
     log.info(f'Publishing online limit command: {payload}')
+
+def zendure_update(payload=json.dumps({"properties": ["getAll"]})):
+    global zendure_client
+    zendure_client.publish(f'iot/{device_details["productKey"]}/{device_details["deviceKey"]}/properties/read', payload)
+    log.info(f'Publishing read command: {payload}')
 
 @socketio.on('setLimit')
 def setLimit(msg):

--- a/src/solarflow-status.py
+++ b/src/solarflow-status.py
@@ -31,7 +31,8 @@ config = load_config()
 
 ZEN_USER = config.get('zendure', 'login', fallback=None) or os.environ.get('ZEN_USER',None)
 ZEN_PASSWD = config.get('zendure', 'password', fallback=None) or os.environ.get('ZEN_PASSWD',None)
-ZEN_API = config.get('zendure', 'zen_api', fallback='https://app.zendure.tech/v2') or os.environ.get('ZEN_API','https://app.zendure.tech/v2')
+ZEN_API = config.get('zendure', 'zen_api', fallback=None) or os.environ.get('ZEN_API','https://app.zendure.tech/v2')
+ZEN_MQTT_HOST = config.get('zendure', 'zen_mqtt', fallback=None) or os.environ.get('ZEN_MQTT','mq.zen-iot.com')
 MQTT_HOST = config.get('local', 'mqtt_host', fallback=None) or os.environ.get('MQTT_HOST',None)
 MQTT_PORT = config.getint('local', 'mqtt_port', fallback=1883) or int(os.environ.get('MQTT_PORT',1883))
 MQTT_USER = config.get('local', 'mqtt_user', fallback=None) or os.environ.get('MQTT_USER',None)
@@ -45,7 +46,7 @@ if MQTT_HOST is None:
 ZenAuth = namedtuple("ZenAuth",["productKey","deviceKey","clientId"])
 
 # MQTT broker where we subscribe to all the telemetry data we need to steer
-broker = config.get('zendure', 'zen_mqtt', fallback='mq.zen-iot.com') or os.environ.get('ZEN_MQTT','mq.zen-iot.com')
+broker = ZEN_MQTT_HOST
 port = 1883
 zendure_client: mqtt_client
 

--- a/src/solarflow-status.py
+++ b/src/solarflow-status.py
@@ -33,6 +33,8 @@ ZEN_USER = config.get('zendure', 'login', fallback=None) or os.environ.get('ZEN_
 ZEN_PASSWD = config.get('zendure', 'password', fallback=None) or os.environ.get('ZEN_PASSWD',None)
 ZEN_API = config.get('zendure', 'zen_api', fallback=None) or os.environ.get('ZEN_API','https://app.zendure.tech/v2')
 ZEN_MQTT_HOST = config.get('zendure', 'zen_mqtt', fallback=None) or os.environ.get('ZEN_MQTT','mq.zen-iot.com')
+ZEN_MQTT_USER = "zenAPP"
+ZEN_MQTT_PWD = config.get('zendure', 'zen_mqtt_pwd', fallback=None) or os.environ.get('ZEN_MQTT_PWD','H6s$j9CtNa0N' if "eu" in ZEN_MQTT_HOST else 'oK#PCgy6OZxd')
 MQTT_HOST = config.get('local', 'mqtt_host', fallback=None) or os.environ.get('MQTT_HOST',None)
 MQTT_PORT = config.getint('local', 'mqtt_port', fallback=1883) or int(os.environ.get('MQTT_PORT',1883))
 MQTT_USER = config.get('local', 'mqtt_user', fallback=None) or os.environ.get('MQTT_USER',None)
@@ -242,7 +244,7 @@ def on_local_disconnect(client, userdata, rc):
 def connect_zendure_mqtt(client_id) -> mqtt_client:
     global zendure_client
     zendure_client = mqtt_client.Client(client_id=client_id, userdata="Zendure Production MQTT")
-    zendure_client.username_pw_set(username="zenApp", password="oK#PCgy6OZxd")
+    zendure_client.username_pw_set(username=ZEN_MQTT_USER, password=ZEN_MQTT_PWD)
     zendure_client.reconnect_delay_set(min_delay=1, max_delay=120)
     zendure_client.on_connect = on_connect
     zendure_client.on_disconnect = on_zendure_disconnect


### PR DESCRIPTION
Hi,

first of all - thanks very very much for this project. I was waiting more then a half year that Zendure will add local and/or command support out of the box for my Zendure Hyper 2000, but nothing happens (except one more cloud device support for evhome).

Then I found your projects and the idea was born to control my Hyper 2000 with my HomeAssistant. Because I use the Hyper 2000 just as AC battery (no panels attached) I only need to adjust the output/input limits and the change between them.
But the status page don't work out of the box with my (eu server) device.

First of all there were configs with a set fallback, which made it impossible, that the "or" condition could match (an error I saw in your other projects, too). Then I added defaults for the eu server and replaced the time-sync by properties/read (also used by solar-control and the iobroker integration). And to force an update of all values I added a forwarder feature for read commands, too.

If I should change anything, split the PR or something, I will do it as fast as possible.

Best regards